### PR TITLE
productテーブルの設定変更及び、ビューの修正

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -3,6 +3,7 @@ class AddressesController < ApplicationController
   before_action :set_user, only: [:new, :create, :update ]
 
   def new
+    @categories = Category.where(ancestry: nil)
     if @address = Address.find_by(user_id: @user.id)
     else
       @address = Address.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update]
 
   def edit
+    @categories = Category.where(ancestry: nil)
   end
 
   def update

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -1,4 +1,4 @@
-= render 'templates/search-header'
+= render 'templates/search-header', categories: @categories
 .user-menu
   .user-menu__level
     %span 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,4 +1,4 @@
-= render 'templates/search-header'
+= render 'templates/search-header', categories: @categories
 .user-menu
   .user-menu__level
     %span 

--- a/db/migrate/20200620032726_create_products.rb
+++ b/db/migrate/20200620032726_create_products.rb
@@ -5,12 +5,12 @@ class CreateProducts < ActiveRecord::Migration[5.2]
       t.text :text, null: false
       t.integer :price, null: false, index: true
       t.string :brand, index: true
-      t.references :category, null: false, foreign_key: true
-      t.references :size, foreign_key: true
-      t.references :status, foreign_key: true
-      t.references :postage, null: false, foreign_key: true
-      t.references :area, null: false, foreign_key: true
-      t.references :shipping_date, null: false, foreign_key: true
+      t.references :category, null: false
+      t.references :size
+      t.references :status
+      t.references :postage, null: false
+      t.references :area, null: false
+      t.references :shipping_date, null: false
       t.boolean :purchase, null: false, default: false
       t.timestamps
     end


### PR DESCRIPTION
# What
productテーブルのマスターテーブルにかかっている外部キーの制約を取り外した
また、カテゴリーテーブルが絡んでいるビューの修正を行った
# Why
外部キーがあるせいでproductテーブルへの保存が上手くいかないため